### PR TITLE
Implement YOLOv8 Kafka tracking service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# yolo8
+# YOLOv8 Kafka Tracking Service
+
+This microservice listens to a Kafka topic for messages containing paths to video files stored in Amazon S3. For each video it downloads the file, runs a pre-trained YOLOv8 model to detect and track objects, draws bounding boxes with class labels and tracking IDs, then uploads the annotated video back to S3 and publishes the output key to another Kafka topic.
+
+Object IDs are assigned using the default [ByteTrack](https://github.com/ifzhang/ByteTrack) tracker built into Ultralytics YOLO. Frames are processed headlessly (`show=True` is not used), making the service suitable for server environments. The annotated video and Kafka notification are produced only when at least one object is detected in the input.
+
+## Requirements
+
+- Python 3.8+
+- Access to a Kafka broker
+- AWS credentials with access to the desired S3 bucket
+- Dependencies listed in `requirements.txt`
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables for your setup:
+   ```bash
+   export KAFKA_BROKER=localhost:9092
+   export INPUT_TOPIC=video_paths
+   export OUTPUT_TOPIC=processed_videos
+   export S3_BUCKET=your-bucket
+   export AWS_REGION=us-east-1
+   # AWS credentials can be provided via environment variables or IAM roles
+   ```
+3. Start the service:
+   ```bash
+   python service.py
+   ```
+
+Messages consumed from the `INPUT_TOPIC` should contain the S3 object key for a video file. The processed video is uploaded to the same bucket under a `processed/` prefix and the new key is published to the `OUTPUT_TOPIC`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ultralytics
+boto3
+kafka-python
+opencv-python

--- a/service.py
+++ b/service.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+from kafka import KafkaConsumer, KafkaProducer
+import boto3
+import cv2
+from ultralytics import YOLO
+
+KAFKA_BROKER = os.getenv('KAFKA_BROKER', 'localhost:9092')
+INPUT_TOPIC = os.getenv('INPUT_TOPIC', 'video_paths')
+OUTPUT_TOPIC = os.getenv('OUTPUT_TOPIC', 'processed_videos')
+S3_BUCKET = os.getenv('S3_BUCKET', 'videos')
+AWS_REGION = os.getenv('AWS_REGION', 'us-east-1')
+
+s3 = boto3.client('s3', region_name=AWS_REGION)
+consumer = KafkaConsumer(INPUT_TOPIC, bootstrap_servers=[KAFKA_BROKER])
+producer = KafkaProducer(bootstrap_servers=[KAFKA_BROKER])
+model = YOLO('yolov8n.pt')
+
+
+def process_video(s3_key: str) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = os.path.join(tmpdir, os.path.basename(s3_key))
+        output_path = os.path.join(tmpdir, f"tracked_{os.path.basename(s3_key)}")
+        s3.download_file(S3_BUCKET, s3_key, input_path)
+
+        cap = cv2.VideoCapture(input_path)
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+        cap.release()
+
+        writer = cv2.VideoWriter(
+            output_path, cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height)
+        )
+
+        detections_found = False
+        # model.track uses ByteTrack by default to assign persistent IDs
+        # show=True is omitted so the service runs headlessly
+        for result in model.track(source=input_path, stream=True):
+            if len(result.boxes) > 0:
+                detections_found = True
+            frame = result.plot()
+            writer.write(frame)
+        writer.release()
+
+        if detections_found:
+            output_key = f"processed/{os.path.basename(output_path)}"
+            s3.upload_file(output_path, S3_BUCKET, output_key)
+            producer.send(OUTPUT_TOPIC, output_key.encode("utf-8"))
+            producer.flush()
+        else:
+            print("No objects detected; skipping upload and Kafka message")
+
+
+def main() -> None:
+    for msg in consumer:
+        s3_key = msg.value.decode('utf-8')
+        try:
+            process_video(s3_key)
+        except Exception as exc:
+            print(f"Error processing {s3_key}: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Kafka-powered microservice to download videos from S3, track objects with YOLOv8, and publish processed video paths
- document ByteTrack usage and headless processing; upload results and send Kafka message only when detections exist

## Testing
- `python -m py_compile service.py`


------
https://chatgpt.com/codex/tasks/task_e_68914d7c2c40832183f46afb34be320d